### PR TITLE
Create anonymous volume for oradata

### DIFF
--- a/Dockerfile.23
+++ b/Dockerfile.23
@@ -104,6 +104,7 @@ LABEL org.opencontainers.image.source https://github.com/gvenzl/oci-oracle-free
 
 USER oracle
 WORKDIR ${ORACLE_BASE}
+VOLUME /opt/oracle/oradata
 
 HEALTHCHECK CMD "${ORACLE_BASE}"/healthcheck.sh >/dev/null || exit 1
 


### PR DESCRIPTION
Hi,

I suggest to declare oradata as an anonymous volume. This eases persistence of data accross image upgrade. What do you think of this ?